### PR TITLE
Large icons by default

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1023,7 +1023,7 @@ var StoreOptions = {
         type: StoreTypes.String
     },
     'iconSizeModifier': {
-        default: 0,
+        default: 10,
         type: StoreTypes.Number
     },
     'scaleByRarity': {


### PR DESCRIPTION
This will make the map load with 'Large' icons by default.